### PR TITLE
Removed dependency on library sh. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
-    install_requires=[
-        'sh', # shell commands
-    ],
     entry_points={
       'console_scripts': [
         'jupyter-theme = jupyterthemes:main',


### PR DESCRIPTION
shutil - part of the standard library - is used instead. Appears to install fine on Windows.