### PR TITLE
fixed duplicate lines in custom.css when toolbar is enabled

### DIFF
--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -91,9 +91,10 @@ def install_theme(name, profile=None, update_properties=False, toolbar=False, fo
                         if toolbar:
                             # -- enable toolbar if requested
                             RESTORE_TOOLBAR='/*'+DEFAULT_TOOLBAR_STRING+'*/'
-                            cssfile.write(line.replace(DEFAULT_TOOLBAR_STRING,RESTORE_TOOLBAR))
+                            line = line.replace(DEFAULT_TOOLBAR_STRING,RESTORE_TOOLBAR)
                         # -- set CodeCell fontsize
-                        cssfile.write(line.replace(DEFAULT_FONTSIZE_STRING, FONTSIZE_STRING))
+                        line = line.replace(DEFAULT_FONTSIZE_STRING, FONTSIZE_STRING)
+                        cssfile.write(line)
             os.close(fh)
             os.remove(customcss_path)
             shutil.move(abs_path, customcss_path)


### PR DESCRIPTION
When toolbar is enabled (-T), write() method was called twice (once after DEFAULT_TOOLBAR_STRING replacement, and once after DEFAULT_FONTSIZE_STRING replacement), creating duplicate lines in the css file. Now, replace() is called twice, but write() is called only once. 