### PR TITLE
fixed --help functionality

### DIFF
--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -94,7 +94,7 @@ def main():
     parser.add_argument('-nbff',"--nbfontfam", action='store', default='sans-serif', help='nb font-family')
     parser.add_argument('-tcff',"--tcfontfam", action='store', default='sans-serif', help='txt font-family')
     parser.add_argument('-cw', "--cellwidth", action='store', default=940, help="set cell width (px)")
-    parser.add_argument('-lh',"--lineheight", action='store', default=160, help='code/text line-height (%)')
+    parser.add_argument('-lh',"--lineheight", action='store', default=160, help='code/text line-height (%%)')
     parser.add_argument('-alt', "--altlayout", action='store_true', default=False, help="alt markdown layout")
     parser.add_argument('-T', "--toolbar", action='store_true', default=False, help="enable the toolbar")
     parser.add_argument('-r', "--reset", action='store_true', help="reset to default theme")


### PR DESCRIPTION
If I run `jt --help`, I get the following error because of an unescaped `%` in a help message: `ValueError: unsupported format character ')' (0x29) at index 24`.

I believe this is an argparse gotcha and the fix is to just to replace `%` with `%%`.

related [stackoverflow question](http://stackoverflow.com/questions/21168120/python-argparse-errors-with-in-help-string).

note: i'm using python 3.5.  I'm not sure that matters