### PR TITLE
added support for arbitrary fonts

### DIFF
--- a/jupyterthemes/stylefx.py
+++ b/jupyterthemes/stylefx.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+from warnings import warn
 
 # path to local site-packages/jupyterthemes
 package_dir = os.path.dirname(os.path.realpath(__file__))
@@ -59,7 +60,13 @@ def get_fonts(fontfamily='sans-serif'):
                         'droid': ['Droid Sans Mono', False],
                         'fira': ['Fira Mono', False],
                         'incon': ['Inconsolata', False]}}
-    return fonts_dict[fontfamily]
+    try:
+        result = fonts_dict[fontfamily.lower()]
+    except KeyError:
+        warn("unknown font family: %s" % fontfamily)
+        result = fontfamily
+
+    return result
 
 def import_monofont(style_css, fontname='Source Code Pro', ital=False):
     g_api = '@import url(https://fonts.googleapis.com/css?family={});'


### PR DESCRIPTION
It would be nice to be able to use any font, not just the handful that are listed in `stylefx.py`.  This PR warns about the font being unknown but will put it into the generated `custom.css` without raising an exception.

What was the rationale for having the specific set of fonts?  Is there something I'm missing?  Is there a better way to support arbitrary fonts?