### PR TITLE
switched html output from being monospace

### DIFF
--- a/jupyterthemes/layout/cells.less
+++ b/jupyterthemes/layout/cells.less
@@ -104,7 +104,7 @@ div.edit_mode div.text_cell.unrendered {
 .rendered_html table,
 .rendered_html tr,
 .rendered_html td {
-    font-family: @monofont, monospace;
+    font-family: @text-cell-fontfamily;
     font-size: 9.5pt !important;
     line-height: 145% !important;
     border: 1px solid @table-border;
@@ -131,7 +131,7 @@ table.dataframe,
 }
 .dataframe td,
 .rendered_html td {
-    font-family: @monofont, monospace;
+    font-family: @text-cell-fontfamily;
     font-size: 9.5pt !important;
     color: @table-color;
     background: @df-cell-bg;
@@ -142,7 +142,7 @@ table.dataframe,
 /********** PANDAS SUMMARY **********/
 .dataframe-summary-row tr:last-child,
 .dataframe-summary-col td:last-child {
-    font-family: @notebook-fontfamily;
+    font-family: @text-cell-fontfamily;
     font-size: 10.5pt !important;
     font-weight: 450;
     color: @df-header;
@@ -228,8 +228,8 @@ div.output_area {
     display: -webkit-box;
 }
 div.output_html {
-    font-family: @monofont, monospace;
-    font-size: @monofontsize;
+    font-family: @text-cell-fontfamily;
+    font-size: @text-cell-fontsize;
     color: @table-color;
     background-color: @cc-output-bg;
     background: @cc-output-bg;


### PR DESCRIPTION
Currently, HTML output from `IPython.display.HTML` is displayed using the monospaced font rather than the text cell font.

master (grade3 theme):
![screen shot 2016-08-01 at 2 01 28 pm](https://cloud.githubusercontent.com/assets/181744/17305553/8b8f31ba-57f0-11e6-81a2-8f0f074d8794.png)

this PR (grade3 theme):
![screen shot 2016-08-01 at 2 01 47 pm](https://cloud.githubusercontent.com/assets/181744/17305562/9267616a-57f0-11e6-8637-49df12105aa8.png)

