### PR TITLE
applying theme to auto-complete menu

### DIFF
--- a/jupyterthemes/layout/completer.less
+++ b/jupyterthemes/layout/completer.less
@@ -1,0 +1,23 @@
+.completions {
+    position: absolute;
+    z-index: 110;
+    overflow: hidden;
+    border: medium solid @cc-border-selected;
+    .corner-all;
+    .box-shadow(0px 6px 10px -1px @box-shadow);
+    line-height: 1;
+}
+
+.completions select {
+    background: @cc-input-bg;
+    outline: none;
+    border: none;
+    padding: 0px;
+    margin: 0px;
+    overflow: auto;
+    font-family: @monofont, monospace; 
+    font-size: @monofontsize;
+    color: @cc-input-fg;
+    width: auto;
+}
+

--- a/jupyterthemes/stylefx.py
+++ b/jupyterthemes/stylefx.py
@@ -33,6 +33,7 @@ cl_style = os.path.join(layouts_dir, 'cells.less')
 ex_style = os.path.join(layouts_dir, 'extras.less')
 jax_style = os.path.join(layouts_dir, 'mathjax.css')
 vim_style = os.path.join(layouts_dir, 'vim.less')
+comp_style = os.path.join(layouts_dir, 'completer.less')
 
 def check_directories():
     # Ensure all install dirs exist
@@ -216,6 +217,9 @@ def style_layout(style_less, theme='grade3', cursorwidth=2, cursorcolor='default
     # read-in codemirror.less (syntax-highlighting)
     with open(cm_style, 'r') as codemirror:
         style_less += codemirror.read() + '\n'
+    with open(comp_style, 'r') as codemirror:
+        style_less += codemirror.read() + '\n'
+
     style_less += toggle_settings(toolbar, nbname, hideprompt) +'\n'
 
     if vimext:


### PR DESCRIPTION
Hi, 

While working on the [solarized theme as discussed](https://github.com/dunovank/jupyter-themes/issues/65)  (thanks for the encouragements btw way :) ) , I noticed the theme is currently not applied to the auto-complete menu. Namely, the font-size and background appear as default (see pictures below). 

I think we can fix that simply by applying the code style to the popup, with the `less` file attached. 

What do you think ? 

Also, good luck for your dissertation :) 
# Before this patch
- chesterish

![image](https://cloud.githubusercontent.com/assets/1214071/19448753/69cb9c86-94a3-11e6-8b7f-47a893c47caf.png)
- grade3

![image](https://cloud.githubusercontent.com/assets/1214071/19448803/970dd9ca-94a3-11e6-87ee-1543b5681a1f.png)
- oceans16

![image](https://cloud.githubusercontent.com/assets/1214071/19448913/fa51e7e2-94a3-11e6-9014-0250103c306b.png)
- onedork 

![image](https://cloud.githubusercontent.com/assets/1214071/19448947/1a6906c8-94a4-11e6-919e-95305cc01329.png)
# with this patch
- chesterish

![image](https://cloud.githubusercontent.com/assets/1214071/19449130/9e19c08e-94a4-11e6-96b0-95031add6c4a.png)
- grade3

![image](https://cloud.githubusercontent.com/assets/1214071/19449162/bb6db0c8-94a4-11e6-93f8-f9f6f6220261.png)
- oceans16

![image](https://cloud.githubusercontent.com/assets/1214071/19449204/e06b92be-94a4-11e6-9091-72f8176c43cc.png)
- onedork

![image](https://cloud.githubusercontent.com/assets/1214071/19449075/7234a498-94a4-11e6-954f-a7041e1f6569.png)
