### PR TITLE
Add support to user less/precompiled themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,18 @@ usage: jt [-h] [-l] [-t THEME] [-f MONOFONT] [-fs MONOSIZE] [-nf NBFONT]
 ```sh
 # list available themes
 # oceans16 | grade3 | chesterish | onedork
+# available themes are marked with keywords:
+#     user - global - precompiled
+# user themes are stored in:
+#     ~/.jupyter-themes/styles
+# themes available in precompiled (css) form only are stored in:
+#     ~/.jupyter-themes/styles/compiled
 jt -l
 
 # select theme...
+# note that customization options have no effect on precompiled themes
+# available themes are searched in the following order:
+#     user > user precompiled > global > global precompiled
 jt -t chesterish
 
 # toggle toolbar ON and notebook name ON

--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -17,12 +17,18 @@ __version__ = '.'.join([str(v) for v in [major, minor, patch]])
 # path to local site-packages/jupyterthemes
 package_dir = os.path.dirname(os.path.realpath(__file__))
 
+# path to user jupyter-themes dir
+user_dir = os.path.join(os.path.expanduser('~'), '.jupyter-themes')
+
 def get_themes():
     """ return list of available themes """
     styles_dir = os.path.join(package_dir, 'styles')
+    styles__dir_user = os.path.join(user_dir, 'styles')
     themes = [os.path.basename(theme).replace('.less', '')
               for theme in glob('{0}/*.less'.format(styles_dir))]
-    return themes
+    themes_user = [os.path.basename(theme).replace('.less', '')
+                   for theme in glob('{0}/*.less'.format(styles_dir_user))]
+    return map(lambda t: t + ' (user)', themes_user) + [t for t in themes if t not in themes_user]
 
 def install_theme(theme, monofont='droidmono', monosize=11, nbfont='exosans', nbfontsize=13, tcfont='loraserif', tcfontsize=13, margins='auto', cellwidth=980, lineheight=170, cursorwidth=2, cursorcolor='default', altlayout=False, altprompt=False, hideprompt=False, vimext=False, toolbar=False, nbname=False):
     """ install theme to jupyter_customcss with specified font, fontsize,

--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -39,7 +39,7 @@ def get_themes():
     for theme in glob('{0}/*.css'.format(precompiled_dir_user)):
         name = name=os.path.basename(theme).replace('.css', '')
         if name in names: continue
-        themes.append(Theme(name=name, tags=['user', 'precompiled only']))
+        themes.append(Theme(name=name, tags=['user', 'precompiled']))
         names.append(name)
 
     for theme in glob('{0}/*.less'.format(styles_dir)):
@@ -51,7 +51,7 @@ def get_themes():
     for theme in glob('{0}/*.css'.format(precompiled_dir)):
         name = os.path.basename(theme).replace('.css', '')
         if name in names: continue
-        themes.append(Theme(name=name, tags=['global', 'precompiled only']))
+        themes.append(Theme(name=name, tags=['global', 'precompiled']))
         names.append(name)
 
     return themes
@@ -63,6 +63,13 @@ def install_theme(theme, monofont='droidmono', monosize=11, nbfont='exosans', nb
     from jupyterthemes import stylefx
     stylefx.reset_default(False)
     stylefx.check_directories()
+    themes = get_themes()
+
+    for theme_ in themes:
+        if theme_.name ==  theme and 'precompiled' in theme_.tags:
+            stylefx.install_precompiled_theme(theme)
+            return
+
     # initialize style_less & style_css
     style_less = stylefx.set_font_properties(monofont=monofont, monosize=monosize, nbfont=nbfont, nbfontsize=nbfontsize, tcfont=tcfont, tcfontsize=tcfontsize)
     # define some vars for cell layout

--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -107,7 +107,7 @@ def main():
     parser.add_argument('-vim', "--vimext", action='store_true', default=False, help="toggle styles for vim")
     parser.add_argument('-r', "--reset", action='store_true', help="reset to default theme")
     args = parser.parse_args()
-    themes = get_themes()
+    themes = sorted(get_themes(), key=lambda t: t.name)
     maxlen = max(len(theme.name) for theme in themes)
     theme_listing = ['{}    {}({})'.format(theme.name, (maxlen-len(theme.name))*' ', ', '.join(theme.tags))
                      for theme in themes]

--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -108,7 +108,9 @@ def main():
     parser.add_argument('-r', "--reset", action='store_true', help="reset to default theme")
     args = parser.parse_args()
     themes = get_themes()
-    theme_listing = ['{}  ({})'.format(theme.name, ', '.join(theme.tags)) for theme in themes]
+    maxlen = max(len(theme.name) for theme in themes)
+    theme_listing = ['{}    {}({})'.format(theme.name, (maxlen-len(theme.name))*' ', ', '.join(theme.tags))
+                     for theme in themes]
     say_themes = "Available Themes: \n   {}" .format('\n   '.join(theme_listing))
     if args.theme:
         if args.theme not in (theme.name for theme in themes):

--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -31,16 +31,18 @@ def get_themes():
     themes = []
     names = []
 
-    for theme in glob('{0}/*.less'.format(styles_dir_user)):
-        name = name=os.path.basename(theme).replace('.less', '')
-        themes.append(Theme(name=name, tags=['user']))
-        names.append(name)
+    if os.path.isdir(styles_dir_user):
+        for theme in glob('{0}/*.less'.format(styles_dir_user)):
+            name = name=os.path.basename(theme).replace('.less', '')
+            themes.append(Theme(name=name, tags=['user']))
+            names.append(name)
 
-    for theme in glob('{0}/*.css'.format(precompiled_dir_user)):
-        name = name=os.path.basename(theme).replace('.css', '')
-        if name in names: continue
-        themes.append(Theme(name=name, tags=['user', 'precompiled']))
-        names.append(name)
+    if os.path.isdir(precompiled_dir_user):
+        for theme in glob('{0}/*.css'.format(precompiled_dir_user)):
+            name = name=os.path.basename(theme).replace('.css', '')
+            if name in names: continue
+            themes.append(Theme(name=name, tags=['user', 'precompiled']))
+            names.append(name)
 
     for theme in glob('{0}/*.less'.format(styles_dir)):
         name = os.path.basename(theme).replace('.less', '')

--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -24,17 +24,35 @@ user_dir = os.path.join(os.path.expanduser('~'), '.jupyter-themes')
 def get_themes():
     """ return list of available themes """
     styles_dir = os.path.join(package_dir, 'styles')
+    precompiled_dir = os.path.join(package_dir, 'styles', 'compiled')
     styles_dir_user = os.path.join(user_dir, 'styles')
+    precompiled_dir_user = os.path.join(user_dir, 'styles', 'compiled')
     Theme = namedtuple('Theme', ('name', 'tags'))
     themes = []
-
-    for theme in glob('{0}/*.less'.format(styles_dir)):
-        name = os.path.basename(theme).replace('.less', '')
-        themes.append(Theme(name=name, tags=['global']))
+    names = []
 
     for theme in glob('{0}/*.less'.format(styles_dir_user)):
         name = name=os.path.basename(theme).replace('.less', '')
         themes.append(Theme(name=name, tags=['user']))
+        names.append(name)
+
+    for theme in glob('{0}/*.css'.format(precompiled_dir_user)):
+        name = name=os.path.basename(theme).replace('.css', '')
+        if name in names: continue
+        themes.append(Theme(name=name, tags=['user', 'precompiled only']))
+        names.append(name)
+
+    for theme in glob('{0}/*.less'.format(styles_dir)):
+        name = os.path.basename(theme).replace('.less', '')
+        if name in names: continue
+        themes.append(Theme(name=name, tags=['global']))
+        names.append(name)
+
+    for theme in glob('{0}/*.css'.format(precompiled_dir)):
+        name = os.path.basename(theme).replace('.css', '')
+        if name in names: continue
+        themes.append(Theme(name=name, tags=['global', 'precompiled only']))
+        names.append(name)
 
     return themes
 

--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import os, sys
 from argparse import ArgumentParser
 from glob import glob
+from collections import namedtuple
 modules = glob(os.path.dirname(__file__)+"/*.py")
 __all__ = [ os.path.basename(f)[:-3] for f in modules]
 
@@ -24,11 +25,18 @@ def get_themes():
     """ return list of available themes """
     styles_dir = os.path.join(package_dir, 'styles')
     styles_dir_user = os.path.join(user_dir, 'styles')
-    themes = [os.path.basename(theme).replace('.less', '')
-              for theme in glob('{0}/*.less'.format(styles_dir))]
-    themes_user = [os.path.basename(theme).replace('.less', '')
-                   for theme in glob('{0}/*.less'.format(styles_dir_user))]
-    return themes_user + [t for t in themes if t not in themes_user]
+    Theme = namedtuple('Theme', ('name', 'tags'))
+    themes = []
+
+    for theme in glob('{0}/*.less'.format(styles_dir)):
+        name = os.path.basename(theme).replace('.less', '')
+        themes.append(Theme(name=name, tags=['global']))
+
+    for theme in glob('{0}/*.less'.format(styles_dir_user)):
+        name = name=os.path.basename(theme).replace('.less', '')
+        themes.append(Theme(name=name, tags=['user']))
+
+    return themes
 
 def install_theme(theme, monofont='droidmono', monosize=11, nbfont='exosans', nbfontsize=13, tcfont='loraserif', tcfontsize=13, margins='auto', cellwidth=980, lineheight=170, cursorwidth=2, cursorcolor='default', altlayout=False, altprompt=False, hideprompt=False, vimext=False, toolbar=False, nbname=False):
     """ install theme to jupyter_customcss with specified font, fontsize,
@@ -75,9 +83,10 @@ def main():
     parser.add_argument('-r', "--reset", action='store_true', help="reset to default theme")
     args = parser.parse_args()
     themes = get_themes()
-    say_themes = "Available Themes: \n   {}".format('\n   '.join(themes))
+    theme_listing = ['{}  ({})'.format(theme.name, ', '.join(theme.tags)) for theme in themes]
+    say_themes = "Available Themes: \n   {}" .format('\n   '.join(theme_listing))
     if args.theme:
-        if args.theme not in themes:
+        if args.theme not in (theme.name for theme in themes):
             print("Didn't recognize theme name: {}".format(args.theme))
             print(say_themes)
             exit(1)

--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -23,12 +23,12 @@ user_dir = os.path.join(os.path.expanduser('~'), '.jupyter-themes')
 def get_themes():
     """ return list of available themes """
     styles_dir = os.path.join(package_dir, 'styles')
-    styles__dir_user = os.path.join(user_dir, 'styles')
+    styles_dir_user = os.path.join(user_dir, 'styles')
     themes = [os.path.basename(theme).replace('.less', '')
               for theme in glob('{0}/*.less'.format(styles_dir))]
     themes_user = [os.path.basename(theme).replace('.less', '')
                    for theme in glob('{0}/*.less'.format(styles_dir_user))]
-    return map(lambda t: t + ' (user)', themes_user) + [t for t in themes if t not in themes_user]
+    return themes_user + [t for t in themes if t not in themes_user]
 
 def install_theme(theme, monofont='droidmono', monosize=11, nbfont='exosans', nbfontsize=13, tcfont='loraserif', tcfontsize=13, margins='auto', cellwidth=980, lineheight=170, cursorwidth=2, cursorcolor='default', altlayout=False, altprompt=False, hideprompt=False, vimext=False, toolbar=False, nbname=False):
     """ install theme to jupyter_customcss with specified font, fontsize,

--- a/jupyterthemes/stylefx.py
+++ b/jupyterthemes/stylefx.py
@@ -73,7 +73,7 @@ def remove_temp_file():
 def install_precompiled_theme(theme):
     # for Python 3.5, install selected theme from precompiled defaults
     compiled_dir = os.path.join(styles_dir, 'compiled')
-    compiled_dir_user = os.path.join(styles_dir, 'compiled')
+    compiled_dir_user = os.path.join(styles_dir_user, 'compiled')
     if '{}.css'.format(theme) in os.listdir(compiled_dir_user):
         theme_src = os.path.join(compiled_dir_user, '{}.css'.format(theme))
     else:

--- a/jupyterthemes/stylefx.py
+++ b/jupyterthemes/stylefx.py
@@ -8,6 +8,9 @@ import lesscpy
 # path to local site-packages/jupyterthemes
 package_dir = os.path.dirname(os.path.realpath(__file__))
 
+# path to user jupyter-themes dir
+user_dir = os.path.join(os.path.expanduser('~'), '.jupyter-themes')
+
 # path to save tempfile with style_less before reading/compiling
 tempfile = os.path.join(package_dir, 'tempfile.less')
 vimtemp = os.path.join(package_dir, 'vimtemp.less')
@@ -24,6 +27,7 @@ jupyter_nbext = os.path.join(jupyter_data, 'nbextensions')
 # theme colors, layout, and font directories
 layouts_dir = os.path.join(package_dir, 'layout')
 styles_dir = os.path.join(package_dir, 'styles')
+styles_dir_user = os.path.join(user_dir, 'styles')
 fonts_dir = os.path.join(package_dir, 'fonts')
 
 # layout files for notebook, codemirror, cells, mathjax, & vim ext
@@ -69,7 +73,11 @@ def remove_temp_file():
 def install_precompiled_theme(theme):
     # for Python 3.5, install selected theme from precompiled defaults
     compiled_dir = os.path.join(styles_dir, 'compiled')
-    theme_src = os.path.join(compiled_dir, '{}.css'.format(theme))
+    compiled_dir_user = os.path.join(styles_dir, 'compiled')
+    if '{}.css'.format(theme) in os.listdir(compiled_dir_user):
+        theme_src = os.path.join(compiled_dir_user, '{}.css'.format(theme))
+    else:
+        theme_src = os.path.join(compiled_dir, '{}.css'.format(theme))
     theme_dst = os.path.join(jupyter_custom, 'custom.css')
     copyfile(theme_src, theme_dst)
     for fontcode in ['exosans', 'loraserif', 'droidmono', 'firacode']:
@@ -166,7 +174,14 @@ def style_layout(style_less, theme='grade3', cursorwidth=2, cursorcolor='default
     # grade3's altlayout is reverse of default
     if theme=='grade3':
         altlayout = not altlayout
-    style_less += '@import "styles{}";\n'.format(''.join([os.sep, theme]))
+
+    if '{}.less'.format(theme) in os.listdir(styles_dir_user):
+        theme_relpath = os.path.relpath(os.path.join(styles_dir_user, theme), package_dir)
+    else:
+        theme_relpath = os.path.relpath(os.path.join(styles_dir, theme), package_dir)
+
+    style_less += '@import "{}";\n'.format(theme_relpath)
+
     textcell_bg = '@cc-input-bg'
     promptText = '@input-prompt'
     promptBG = '@cc-input-bg'

--- a/jupyterthemes/stylefx.py
+++ b/jupyterthemes/stylefx.py
@@ -74,7 +74,8 @@ def install_precompiled_theme(theme):
     # for Python 3.5, install selected theme from precompiled defaults
     compiled_dir = os.path.join(styles_dir, 'compiled')
     compiled_dir_user = os.path.join(styles_dir_user, 'compiled')
-    if '{}.css'.format(theme) in os.listdir(compiled_dir_user):
+    if (os.path.isdir(compiled_dir_user) and
+            '{}.css'.format(theme) in os.listdir(compiled_dir_user)):
         theme_src = os.path.join(compiled_dir_user, '{}.css'.format(theme))
     else:
         theme_src = os.path.join(compiled_dir, '{}.css'.format(theme))
@@ -175,7 +176,8 @@ def style_layout(style_less, theme='grade3', cursorwidth=2, cursorcolor='default
     if theme=='grade3':
         altlayout = not altlayout
 
-    if '{}.less'.format(theme) in os.listdir(styles_dir_user):
+    if (os.path.isdir(styles_dir_user) and
+            '{}.less'.format(theme) in os.listdir(styles_dir_user)):
         theme_relpath = os.path.relpath(os.path.join(styles_dir_user, theme), package_dir)
     else:
         theme_relpath = os.path.relpath(os.path.join(styles_dir, theme), package_dir)


### PR DESCRIPTION
Hey!

These changes add the ability to use local themes from user's home directory the same way packaged themes are used. The directory structure of `site-packages/jupyterthemes` can be reflected in `~/.jupyter-themes` and extra/modified styles can be dropped there.

I also added the functionality of installing themes available in compatible `css` from either user (if user config dir exists) or packaged themes directory.

If both `.less` and `.css` versions of a certain theme exist, the `.less` version is used. If a theme exists as both a user theme and a global theme, the user theme is used. This came in handy when I wanted to slightly modify one of the packaged thems, I copied the `.less` file with the same file name to my own user themes directory and modified it without touching the one installed with the package. Now I can switch themes and keep my customizations (no need to edit jupyter's own `custom.css`).

The following demonestrates the usage with the new functionility. Notice that `oceans16.less` file exists in my user configuration directory and overshadows the original in `jt -l`. Also notice the file `jdark.css` which is a css only theme i got from the repo: [powerpak/jupyter-dark-theme](https://github.com/powerpak/jupyter-dark-theme). You can see the result of installing it in the screenshot below.

```sh
$ jt -l
Available Themes: 
   chesterish    (global)
   grade3        (global)
   jdark         (user, precompiled)
   oceans16      (user)
   onedork       (global)

$ tree ~/.jupyter-themes
/home/me/.jupyter-themes
└── styles
    ├── compiled
    │   └── jdark.css
    └── oceans16.less

2 directories, 2 files
$ jt -t jdark
$ jupyter-notebook
```
Result:
![jupyter-dark-css-screenshot](https://cloud.githubusercontent.com/assets/3110771/21076993/30131840-bf44-11e6-9368-a68bb3ccbd9f.png)


