### PR TITLE
fix font 404 errors

### DIFF
--- a/jupyterthemes/stylefx.py
+++ b/jupyterthemes/stylefx.py
@@ -214,7 +214,7 @@ def import_fonts(style_less, fontname, font_subdir):
             fontname=fontname,
             weight=weight,
             style=style,
-            sepp=os.sep,
+            sepp='/',
             fontfile=fontfile,
             ftype=ft)
         send_fonts_to_jupyter(os.path.join(fontpath, fontfile))


### PR DESCRIPTION
this fixes #71 
os.sep returns '/' for mac/linux but '\\' on windows, which breaks things when it is in the css