### PR TITLE
Set the width of three container classes to "max-width: 100%"

### DIFF
--- a/jupyterthemes/layout/notebook.less
+++ b/jupyterthemes/layout/notebook.less
@@ -268,19 +268,19 @@ div#notebook {
     background-color: @notebook-bg;
     min-height: 0px;
     box-shadow: none;
-    width: @cell-width;
+    max-width: @cell-width;
     margin-right: auto;
     margin-left: auto;
 }
 div#ipython-main-app.container {
-    width: @cell-width;
+    max-width: @cell-width;
     margin-right: auto;
     margin-left: auto;
     margin-right: @container-margins;
     margin-left: @container-margins;
 }
 .container {
-    width: @cell-width;
+    max-width: @cell-width;
     margin-right: auto;
     margin-left: auto;
 }

--- a/jupyterthemes/layout/notebook.less
+++ b/jupyterthemes/layout/notebook.less
@@ -905,8 +905,8 @@ div.output.output_scroll {
 	border-radius: 6px;
 }
 ::-webkit-scrollbar {
-    width: 14px;
-    height: 20px;
+    width: 6px;
+    height: 8px;
     background-color: @scroll-trough;
     border-radius: 6px;
 }

--- a/jupyterthemes/stylefx.py
+++ b/jupyterthemes/stylefx.py
@@ -342,7 +342,7 @@ def toggle_settings(toolbar=False, nbname=False, hideprompt=False):
             'display: inline-block !important; }')
 
     return toggle
- 
+
 
 def set_mathjax_style(style_css):
     """Improve mathjax fonttype setting in markdown cells"""

--- a/jupyterthemes/stylefx.py
+++ b/jupyterthemes/stylefx.py
@@ -226,7 +226,7 @@ def style_layout(style_less,
                  theme='grade3',
                  cursorwidth=2,
                  cursorcolor='default',
-                 cellwidth='980',
+                 cellwidth='100%',
                  lineheight=170,
                  margins='auto',
                  altlayout=False,
@@ -342,7 +342,7 @@ def toggle_settings(toolbar=False, nbname=False, hideprompt=False):
             'display: inline-block !important; }')
 
     return toggle
-
+ 
 
 def set_mathjax_style(style_css):
     """Improve mathjax fonttype setting in markdown cells"""


### PR DESCRIPTION
Set the width of three container classes to "max-width: 100%" for responsive layout.

- Update cellwidth in stylefx.py to "100%".
- Update the width of three container classes in notebook.less to "max-width: @cell-width".

The result looks much better when browser window is narrowed.