### PR TITLE
added @item-### colors

### DIFF
--- a/jupyterthemes/styles/solarized-dark.less
+++ b/jupyterthemes/styles/solarized-dark.less
@@ -93,6 +93,11 @@ jt -t solarized-light --lineheight=140 --monofont="source"
 @item-green:            @solar-green;
 @item-red:              @solar-red;
 
+@item-danger:           #e16256;
+@item-success:          #83a83b;                                                   
+@item-info:             #3498db;                                                   
+@item-warning:          #ff914d;
+
 /* tables and dataframes colors */
 @table-color:           #353535;
 @table-bg:              @notebook-bg;


### PR DESCRIPTION
fix for error from PR #103 

used colors from onedork theme, which although not same at all as solarized-dark, actually work well considering the warning/error/danger should be high contrast