### PR TITLE
fix the invalid string format

### DIFF
--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -175,7 +175,7 @@ def main():
         "--mathfontsize",
         action='store',
         default='100',
-        help='mathjax fontsize (in %)')
+        help='mathjax fontsize (in %%)')
     parser.add_argument(
         '-m',
         "--margins",


### PR DESCRIPTION
it cause `ValueError: unsupported format character ')'` when i execute `jt -h`,
is here should be written like this?