### PR TITLE
update lesscpy dependency to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jupyter_core
 ipython>=5.4.1
 matplotlib>=1.4.3
-lesscpy>=0.12.0
+lesscpy>=0.11.2

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ fontsdata = chain.from_iterable([[os.sep.join(f.split(os.sep)[1:])
                                  for fsub in fsubdirs])
 datafiles[pkgname].extend(list(fontsdata))
 
-install_requires = ['jupyter_core', 'ipython>=5.4.1', 'matplotlib>=1.4.3', 'lesscpy>=0.12.0']
+install_requires = ['jupyter_core', 'ipython>=5.4.1', 'matplotlib>=1.4.3', 'lesscpy>=0.11.2']
 
 setup(
     name='jupyterthemes',


### PR DESCRIPTION
addresses issue [#213](https://github.com/dunovank/jupyter-themes/issues/213)

Most recent version of `lesscpy` is [0.11.2](https://pypi.python.org/pypi/lesscpy); requiring 0.12.0 in `requirements.txt` causes error on `pip install` or `python setup.py ...`