### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jupyter_core
 ipython>=5.4.1
 matplotlib>=1.4.3
-lesscpy>=0.12.0
+lesscpy>=0.11.2


### PR DESCRIPTION
There might have been an downgrade of the stable release of lesscpy. Now it is 0.11.2, lower than the required 0.12.0. Such conflict is stopping people from upgrading and installing the package.

Please refer to #213 for more details.