### PR TITLE
Change layout/notebook.less file format from UTF-8 to ASCII

### DIFF
--- a/jupyterthemes/layout/notebook.less
+++ b/jupyterthemes/layout/notebook.less
@@ -1581,4 +1581,4 @@ HTML, body, div, dl, dt, dd, ul, ol, li, h1, h2, h3, h4, h5, h6, pre, code, form
 // }
 // .cf {
 //     zoom:1;
-// }​
+// }


### PR DESCRIPTION
Problem
 - File encoding of notebook.less is UTF-8 and contains U+200B (ZERO
     WIDTH_SPACE) which is not compatible with ASCII
 - If system default encoding is not UTF-8, file read fails on
 stylefx.py line 290

Applied solution
 - used 'iconv -f UTF-8 -t ASCII' command to change file encoding
 - U+200B character removed during conversion

Environment
 - OS: run centos:7.3.1611 official docker image with a centos 7.3.1611 host
 - Install python3 & jupyterthemes
 - jt command fails
```
Traceback (most recent call last):
  File "/root/.local/bin/jt", line 11, in <module>
    sys.exit(main())
  File "/root/.local/lib/python3.6/site-packages/jupyterthemes/__init__.py", line 305, in main
    dfonts=args.defaultfonts)
  File "/root/.local/lib/python3.6/site-packages/jupyterthemes/__init__.py", line 98, in install_theme
    nbname=nbname)
  File "/root/.local/lib/python3.6/site-packages/jupyterthemes/stylefx.py", line 291, in style_layout
    style_less += notebook.read() + '\n'
  File "/root/.local/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 41269: ordinal not in range(128)
```

From the Python3 open function reference(https://docs.python.org/3.6/library/functions.html#open) says encoding option follows system default encoding if not given.
Python2 open function reference(https://docs.python.org/2.7/library/functions.html#open) does not have encoding option, however, returning file object will follow system default file encoding(https://docs.python.org/2.7/library/stdtypes.html#file.encoding).

But! Python2 does not use ascii codec for default when Python3 choose ascii as default codec on the same system, so it only happens with Python3.

I don't understand why Python2 doesn't use ascii as default on a system that default encoding is ascii.

Anyway, I checked the encoding of all files that python code opens and only the notebook.less file is UTF-8 formatted.

After I converted the notebook.less using iconv command, everything works fine.
  
I think it will not be a problem on the most system because it only occurs on a system that default encoding is not UTF-8.
  