### PR TITLE
match rendered subheading styles for markdown

### DIFF
--- a/jupyterthemes/layout/cells.less
+++ b/jupyterthemes/layout/cells.less
@@ -524,30 +524,33 @@ div.rendered_html h5 {
 }
 .rendered_html h2,
 .text_cell_render h2 {
-    text-align: left;
+    color: @header-fg;
     font-size: 170%;
-    color: @code-fg;
+    text-align: center;
     font-style: normal;
     font-weight: normal;
 }
 .rendered_html h3,
 .text_cell_render h3 {
+    color: @header-fg;
     font-size: 140%;
-    color: @code-fg;
+    text-align: center;
     font-style: normal;
     font-weight: normal;
 }
 .rendered_html h4,
 .text_cell_render h4 {
+    color: @header-fg;
     font-size: 110%;
-    color: @code-fg;
+    text-align: center;
     font-style: normal;
     font-weight: normal;
 }
 .rendered_html h5,
 .text_cell_render h5 {
+    color: @header-fg;
     font-size: 100%;
-    color: @selected-fg;
+    text-align: center;
     font-style: normal;
     font-weight: normal;
 }


### PR DESCRIPTION
This is my first PR to something. I've modified these cells in my own `custom.css` and it has the desired effect on my rendered markdown headings. 

![image](https://user-images.githubusercontent.com/14908618/36121114-81497992-1002-11e8-8819-1e5098df8eeb.png)
