### PR TITLE
Update cells.less

### DIFF
--- a/jupyterthemes/layout/cells.less
+++ b/jupyterthemes/layout/cells.less
@@ -209,7 +209,7 @@ div.output_html {
 }
 div.output_subarea {
     overflow-x: auto;
-    padding: 0.4em !important;
+    padding: 1.2em !important;
     -webkit-box-flex: 1;
     -moz-box-flex: 1;
     box-flex: 1;

--- a/jupyterthemes/layout/cells.less
+++ b/jupyterthemes/layout/cells.less
@@ -209,7 +209,7 @@ div.output_html {
 }
 div.output_subarea {
     overflow-x: auto;
-    padding: 0.8em !important;
+    padding: 0.4em !important;
     -webkit-box-flex: 1;
     -moz-box-flex: 1;
     box-flex: 1;


### PR DESCRIPTION
Changing
`div.output_subarea {
    overflow-x: auto;
    padding: 0.8em !important;`

`div.output_subarea {
    overflow-x: auto;
    padding: 1.2em !important;`

allows the output cell content to be seen without having being cut
 half character on both sides in screens less large than 16:9

but this is good with default fontsize. With bigger fontsize, padding should be changed accordingly