### PR TITLE
output's collapse button size adjustment

### DIFF
--- a/jupyterthemes/styles/compiled/chesterish.css
+++ b/jupyterthemes/styles/compiled/chesterish.css
@@ -1729,8 +1729,8 @@ div.out_prompt_overlay.prompt {
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
  border-bottom-right-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid transparent;
  color: transparent;
 }
@@ -1743,8 +1743,8 @@ div.out_prompt_overlay.prompt:hover {
  -moz-border-radius: 2px;
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid #374556 !important;
 }
 div.cell.code_cell .output_prompt {

--- a/jupyterthemes/styles/compiled/grade3.css
+++ b/jupyterthemes/styles/compiled/grade3.css
@@ -1729,8 +1729,8 @@ div.out_prompt_overlay.prompt {
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
  border-bottom-right-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid transparent;
  color: transparent;
 }
@@ -1743,8 +1743,8 @@ div.out_prompt_overlay.prompt:hover {
  -moz-border-radius: 2px;
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid #f7f7f7 !important;
 }
 div.cell.code_cell .output_prompt {

--- a/jupyterthemes/styles/compiled/gruvboxd.css
+++ b/jupyterthemes/styles/compiled/gruvboxd.css
@@ -1729,8 +1729,8 @@ div.out_prompt_overlay.prompt {
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
  border-bottom-right-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid transparent;
  color: transparent;
 }
@@ -1743,8 +1743,8 @@ div.out_prompt_overlay.prompt:hover {
  -moz-border-radius: 2px;
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid #928374 !important;
 }
 div.cell.code_cell .output_prompt {

--- a/jupyterthemes/styles/compiled/gruvboxl.css
+++ b/jupyterthemes/styles/compiled/gruvboxl.css
@@ -1729,8 +1729,8 @@ div.out_prompt_overlay.prompt {
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
  border-bottom-right-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid transparent;
  color: transparent;
 }
@@ -1743,8 +1743,8 @@ div.out_prompt_overlay.prompt:hover {
  -moz-border-radius: 2px;
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid #928374 !important;
 }
 div.cell.code_cell .output_prompt {

--- a/jupyterthemes/styles/compiled/monokai.css
+++ b/jupyterthemes/styles/compiled/monokai.css
@@ -1729,8 +1729,8 @@ div.out_prompt_overlay.prompt {
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
  border-bottom-right-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid transparent;
  color: transparent;
 }
@@ -1743,8 +1743,8 @@ div.out_prompt_overlay.prompt:hover {
  -moz-border-radius: 2px;
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid #49483e !important;
 }
 div.cell.code_cell .output_prompt {

--- a/jupyterthemes/styles/compiled/oceans16.css
+++ b/jupyterthemes/styles/compiled/oceans16.css
@@ -1729,8 +1729,8 @@ div.out_prompt_overlay.prompt {
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
  border-bottom-right-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid transparent;
  color: transparent;
 }
@@ -1743,8 +1743,8 @@ div.out_prompt_overlay.prompt:hover {
  -moz-border-radius: 2px;
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid #3e4458 !important;
 }
 div.cell.code_cell .output_prompt {

--- a/jupyterthemes/styles/compiled/onedork.css
+++ b/jupyterthemes/styles/compiled/onedork.css
@@ -1729,8 +1729,8 @@ div.out_prompt_overlay.prompt {
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
  border-bottom-right-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid transparent;
  color: transparent;
 }
@@ -1743,8 +1743,8 @@ div.out_prompt_overlay.prompt:hover {
  -moz-border-radius: 2px;
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid #3e4458 !important;
 }
 div.cell.code_cell .output_prompt {

--- a/jupyterthemes/styles/compiled/solarizedd.css
+++ b/jupyterthemes/styles/compiled/solarizedd.css
@@ -1729,8 +1729,8 @@ div.out_prompt_overlay.prompt {
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
  border-bottom-right-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid transparent;
  color: transparent;
 }
@@ -1743,8 +1743,8 @@ div.out_prompt_overlay.prompt:hover {
  -moz-border-radius: 2px;
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid #05262f !important;
 }
 div.cell.code_cell .output_prompt {

--- a/jupyterthemes/styles/compiled/solarizedl.css
+++ b/jupyterthemes/styles/compiled/solarizedl.css
@@ -1729,8 +1729,8 @@ div.out_prompt_overlay.prompt {
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
  border-bottom-right-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid transparent;
  color: transparent;
 }
@@ -1743,8 +1743,8 @@ div.out_prompt_overlay.prompt:hover {
  -moz-border-radius: 2px;
  border-top-right-radius: 0px;
  border-top-left-radius: 0px;
- min-width: 14.5ex !important;
- width: 14.5ex !important;
+ min-width: 11.5ex !important;
+ width: 11.5ex !important;
  border-right: 2px solid #e8e0c7 !important;
 }
 div.cell.code_cell .output_prompt {


### PR DESCRIPTION
This resizes the collapse button so the output can be read properly
The button previously would cover the beggining of the output.
fixes #203 and fixes #273 