### PR TITLE
Fixed toolbar colors in the terminal app

### DIFF
--- a/jupyterthemes/layout/extras.less
+++ b/jupyterthemes/layout/extras.less
@@ -742,6 +742,9 @@ div#short-key-bindings-intro.well, .well {
 .terminal-app {
     background: @notebook-bg;
 }
+.terminal-app > #header {
+    background: @notebook-bg;
+}
 .terminal-app .terminal {
     font-family: @monofont, monospace;
     font-size: @monofontsize;


### PR DESCRIPTION
The toolbar color when using the terminal app is set to `@body-bg` (white) in jupyter's [terminal.less](https://github.com/jupyter/notebook/blob/c2a2bcc4a7344652ae9229931fc2323ba67d7d4c/notebook/static/terminal/less/terminal.less#L5). That rule has higher specificity than the one in the theme's notebook.less file and so takes precedence, making the toolbar white.

![image](https://user-images.githubusercontent.com/3891092/46675081-f5644400-cbdd-11e8-9643-64ea6858df69.png)

This PR adds another rule with the same specificity to override it.

![image](https://user-images.githubusercontent.com/3891092/46675158-16c53000-cbde-11e8-9fce-606f3d8703c6.png)
