### PR TITLE
Yellow matching brackets

### DIFF
--- a/jupyterthemes/styles/gruvboxd.less
+++ b/jupyterthemes/styles/gruvboxd.less
@@ -51,7 +51,7 @@
 @selected-active:       @selected-half;
 @navbar-selected:       @selected-third;
 @selected-fg:           @gruv-base0;
-@selected-fg-bright:    @blue;
+@selected-fg-bright:    @yellow;
 @unemphasize-fg:        @gruv-base1;
 
 /* code, text, markdown, & tooltip colors */
@@ -83,7 +83,7 @@
 @prompt-hover-color:    @gruv-base01;
 @prompt-line:           @cc-border-edit;
 @tc-prompt-std:         rgba(215, 153, 33, .50);
-@matching-bracket:      @gruv-base3;
+@matching-bracket:      @gruv-base00;
 @menubar-bg:            darken(@notebook-bg, 3%);
 @menubar-fg:            @notebook-fg;
 @menubar-hover:         @dropdown-bg;


### PR DESCRIPTION
When the cursor was placed on a bracket the highlighting (blue on grey) made it difficult for me to tell _what_ was being matched (whether `)` or `}` or `]`). Also see #252.