### PR TITLE
Fix long_description for PyPi site

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,17 +14,13 @@ download_url = '/'.join([url, 'tarball', 'v' + version])
 
 # get readme content after screenshots for pypi site
 README = os.path.join(os.path.dirname(__file__), 'README.md')
-with open(README) as read_me:
-    longdescr = ''
-    startReading = False
-    for line in read_me:
-        if "Travis" in line.strip():
-            startReading = True
-        if "Monospace Fonts" in line.strip():
-            break
-        if startReading:
-            longdescr += line
 
+longdescr = ''
+with open(README) as read_me:
+    for line in read_me:
+        if "Monospace Fonts" in line:
+            break
+        longdescr += line
 
 # add layout, .less styles, and compiled .css files to pkg data
 layout = os.path.join(pkgname, 'layout')


### PR DESCRIPTION
The PyPi project still doesn't have a long_description:
![image](https://user-images.githubusercontent.com/25161069/52217980-8a780080-2891-11e9-97c3-039f9415af05.png)
This is because in the `setup.py`, you only start reading the README when a line contains `"Travis"`:
```python
        if "Travis" in line.strip():
            startReading = True
```
However, the README only contains the string *`travis`*:
![image](https://user-images.githubusercontent.com/25161069/52218143-ed699780-2891-11e9-82c0-bd49bf00ebb5.png)

This PR just reads everything in the README up to the `Monospace Fonts` header, since there's no reason to exclude the headers at the top.