### PR TITLE
Fix Solarized Light inverse Color

### DIFF
--- a/jupyterthemes/styles/solarizedl.less
+++ b/jupyterthemes/styles/solarizedl.less
@@ -22,7 +22,7 @@ http://ethanschoonover.com/solarized
 @code-orange:           @orange;
 @code-cyan:             @cyan;
 @theme-flavor:          #ffffff;
-@theme-flavor-inverse:  #ffffff;
+@theme-flavor-inverse:  #000000;
 
 @solar-base03:          #002b36;
 @solar-base02:          #073642;


### PR DESCRIPTION
Fixes Issue #311, where the matching parentheses in Solarized Light are set to white rather than a contrasting color. I followed the lead of the Solarized Dark theme (theme flavor is black, inverse is white) but reversed.