### PR TITLE
Set color for fat-cursor of vim

### DIFF
--- a/jupyterthemes/layout/vim.less
+++ b/jupyterthemes/layout/vim.less
@@ -33,3 +33,7 @@
   background-color: @cc-input-bg;
   color: @cc-input-fg;
 }
+
+.cm-fat-cursor .CodeMirror-cursor {
+  background: @cursor-color
+}

--- a/jupyterthemes/stylefx.py
+++ b/jupyterthemes/stylefx.py
@@ -321,7 +321,7 @@ def style_layout(style_less,
     style_less += toggle_settings(
         toolbar, nbname, hideprompt, kernellogo) + '\n'
     if vimext:
-        set_vim_style(theme)
+        set_vim_style(theme, cursorcolor=cursorcolor)
 
     return style_less
 
@@ -421,7 +421,7 @@ def set_mathjax_style(style_css, mathfontsize):
 
 
 
-def set_vim_style(theme):
+def set_vim_style(theme, cursorcolor='default'):
     """Add style and compatibility with vim notebook extension"""
 
     vim_jupyter_nbext = os.path.join(jupyter_nbext, 'vim_binding')
@@ -430,7 +430,7 @@ def set_vim_style(theme):
         os.makedirs(vim_jupyter_nbext)
 
     vim_less = '@import "styles{}";\n'.format(''.join([os.sep, theme]))
-
+    vim_less += '@cursor-color: {}; \n'.format(cursorcolor)
     with open(vim_style, 'r') as vimstyle:
         vim_less += vimstyle.read() + '\n'
     with open(vimtemp, 'w') as vtemp:


### PR DESCRIPTION
When vim-mode plugin is activated, cursor color preference is not applied to the fat-cursor or a style of the cursor in command mode as the below figure.
<img width="400" alt="scrrenshot 2019-07-03 0 13 32" src="https://user-images.githubusercontent.com/16137578/60524394-6e389c80-9d27-11e9-8459-d6340891d84f.png">

This PR fixes this.