### PR TITLE
fix user themes support

### DIFF
--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -19,9 +19,12 @@ __version__ = '.'.join([str(v) for v in [major, minor, patch]])
 
 def get_themes():
     """ return list of available themes """
-    styles_dir = os.path.join(package_dir, 'styles')
+    styles_dir = stylefx.styles_dir
+    styles_dir_user = stylefx.styles_dir_user
     themes = [os.path.basename(theme).replace('.less', '')
               for theme in glob('{0}/*.less'.format(styles_dir))]
+    themes += [os.path.basename(theme).replace('.less', '')
+               for theme in glob('{0}/*.less'.format(styles_dir_user))]
     return themes
 
 


### PR DESCRIPTION
According to `stylefx.style_layout` logic, there is user themes support (although, I didn't found it in docs).
```
    if (os.path.isdir(styles_dir_user) and
            '{}.less'.format(theme) in os.listdir(styles_dir_user)):
        theme_relpath = os.path.relpath(
            os.path.join(styles_dir_user, theme), package_dir)
    else:
        theme_relpath = os.path.relpath(
            os.path.join(styles_dir, theme), package_dir)
```
But `get_themes()` function does not list user themes, and "Didn't recognize theme name" error message is shown.
This pull request solves it by adding user's `~/.jupyter-themes/styles/*.less` files to `get_themes()` listing.