### PR TITLE
Update toolbar styles to prevent horizontal scroll on larger screens

### DIFF
--- a/jupyterthemes/layout/notebook.less
+++ b/jupyterthemes/layout/notebook.less
@@ -35,7 +35,6 @@ a:hover, a:focus {
     -webkit-font-smoothing: antialiased !important;
 }
 div#maintoolbar {
-    position: absolute;
     width: 90%;
     margin-left: -10%;
     padding-right: 8%;
@@ -45,7 +44,7 @@ div#maintoolbar {
     background-color: @notebook-bg !important;
 }
 #maintoolbar {
-    margin-bottom: -3px;
+    margin-bottom: 10px;
     margin-top: 2px !important;
     border: 0px;
     min-height: 27px;


### PR DESCRIPTION
On larger screens the toolbar causes a horizontal scrollbar because the body is larger than the screen. This fix removes that unnecessary scrollbar, along with slight style improvements.