### PR TITLE
[*] changed colorscheme with regard to the original solarized.vim file

### DIFF
--- a/jupyterthemes/styles/solarizedd.less
+++ b/jupyterthemes/styles/solarizedd.less
@@ -36,7 +36,7 @@ http://ethanschoonover.com/solarized
 
 /* solarized notebook colors */
 @notebook-bg:           @solar-base03;
-@notebook-fg:           @solar-base01;
+@notebook-fg:           @solar-base0;
 @notebook-base:         @notebook-bg;
 
 /* jtplot figure style */
@@ -166,7 +166,7 @@ http://ethanschoonover.com/solarized
 @cm-linenumber:         @solar-base00;
 @cm-atom:               @magenta;
 @cm-attribute:          @magenta;
-@cm-comment:            @solar-base1;
+@cm-comment:            @solar-base01;
 @cm-property:           @blue;
 @cm-keyword:            @green;
 @cm-string:             @cyan;


### PR DESCRIPTION
This solves #376 . 
With regard to the original solarized dark theme in [solarized.vim](https://github.com/altercation/vim-colors-solarized/blob/528a59f26d12278698bb946f8fb82a63711eec21/colors/solarized.vim#L539) you have a bit changed color usage. Color codes themselves are ok, but wrongly assigned to roles.
This correction changes inversion between comment and code in brightness.