### PR TITLE
Restore customization in custom.js

### DIFF
--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -48,13 +48,17 @@ def install_theme(theme=None,
                 toolbar=False,
                 nbname=False,
                 kernellogo=False,
-                dfonts=False):
+                dfonts=False,
+                keepcustom=False):
 
     """ Install theme to jupyter_customcss with specified font, fontsize,
     md layout, and toolbar pref
     """
     # get working directory
     wkdir = os.path.abspath('./')
+
+    if keepcustom:
+        stylefx.save_customizations()
 
     stylefx.reset_default(False)
     stylefx.check_directories()
@@ -110,6 +114,11 @@ def install_theme(theme=None,
 
     # change back to original working directory
     os.chdir(wkdir)
+
+    # restore customization from custom.js
+    if keepcustom:
+        stylefx.restore_customizations()
+
 
 def main():
     parser = ArgumentParser()
@@ -267,6 +276,12 @@ def main():
         action='store_true',
         default=False,
         help="force fonts to browser default")
+    parser.add_argument(
+        '-kc',
+        "--keepcustom",
+        default=False,
+        action='store_true',
+        help="keep customization: do not reset jupyter notebook custom.js")
 
     args = parser.parse_args()
     themes = get_themes()
@@ -311,4 +326,5 @@ def main():
         toolbar=args.toolbar,
         nbname=args.nbname,
         kernellogo=args.kernellogo,
-        dfonts=args.defaultfonts)
+        dfonts=args.defaultfonts,
+        keepcustom=args.keepcustom)

--- a/jupyterthemes/stylefx.py
+++ b/jupyterthemes/stylefx.py
@@ -36,6 +36,9 @@ defaults_dir = os.path.join(package_dir, 'defaults')
 defaultCSS = os.path.join(defaults_dir, 'custom.css')
 defaultJS = os.path.join(defaults_dir, 'custom.js')
 
+# custom.js before use of JT, use in restoring customizations
+temp_customjs = os.path.join(jupyter_custom, 'temp_custom.js')
+
 # layout files for notebook, codemirror, cells, mathjax, & vim ext
 nb_style = os.path.join(layouts_dir, 'notebook.less')
 cm_style = os.path.join(layouts_dir, 'codemirror.less')
@@ -469,6 +472,16 @@ def reset_default(verbose=False):
 
     if verbose:
         print("Reset css and font defaults in:\n{} &\n{}".format(*paths))
+
+
+def save_customizations():
+    print('saving custom.js for restoring')
+    os.rename(jupyter_customjs, temp_customjs)
+
+
+def restore_customizations():
+    print('restoring customization in custom.js')
+    os.rename(temp_customjs, jupyter_customjs)
 
 
 def set_nb_theme(name):


### PR DESCRIPTION
Customizations found in custom.js are overwritten when using JT. 
This PR adds a CLI argument (-kc or --keepcustom) that will restore customization from custom.js

Related issues: #426 #357 #415