### PR TITLE
Fix Issues #204, #377

### DIFF
--- a/jupyterthemes/layout/codemirror.less
+++ b/jupyterthemes/layout/codemirror.less
@@ -120,6 +120,7 @@ div.tooltiptext.bigtooltip {
     border-radius: 2px;
     font-style: normal;
     font-weight: normal;
+    padding-right: 1.2em;
 }
 .cm-s-ipython div.CodeMirror-selected {
     background: @cm-selected;


### PR DESCRIPTION
Added right padding to match CodeMirror to input_area and prevent cutting the last char of a long code line, relating to Issues #204 and #377 

I also suggest a new release to PyPI, so that new users won't have the same problem, as I also had an issue with the output padding that was already solved.

