### PR TITLE
Make .dynamic-buttons have width: 100%

### DIFF
--- a/jupyterthemes/layout/notebook.less
+++ b/jupyterthemes/layout/notebook.less
@@ -1163,6 +1163,7 @@ button.close {
 .dynamic-buttons {
     padding-top: 0px;
     display: inline-block;
+    width: 100%;
 }
 .close {
     color: @item-red;


### PR DESCRIPTION
# Summary
- Make .dynamic-buttons expand to fill horizontal space to render better when there are many buttons.
- Currently, .dynamic-buttons is hard-coded to width: 400px.
- When there are many dynamic buttons the 400px width causes overflow to another line.

# Before
![before](https://user-images.githubusercontent.com/1892049/110838036-fea2e080-826f-11eb-8b94-f37d1e949dc3.png)

# After
![after](https://user-images.githubusercontent.com/1892049/110837830-bd123580-826f-11eb-84f4-7fdb2ab292a4.png)

