### PR TITLE
Fix brackets highlighting in "solarizedl"

### DIFF
--- a/jupyterthemes/styles/solarizedl.less
+++ b/jupyterthemes/styles/solarizedl.less
@@ -22,7 +22,7 @@ http://ethanschoonover.com/solarized
 @code-orange:           @orange;
 @code-cyan:             @cyan;
 @theme-flavor:          #ffffff;
-@theme-flavor-inverse:  #ffffff;
+@theme-flavor-inverse:  #000000;
 
 @solar-base03:          #002b36;
 @solar-base02:          #073642;


### PR DESCRIPTION
This fixes #311.

This makes the value `theme-flavor-inverse` in "solarizedl" actually an inverse of `theme-flavor`. All the dark themes have them differing, but in the light themes they are currently the same. The other light themes don't encounter the issue above, because they use a custom background color for highlighted brackets, but maybe they should be fixed accordingly too. In that case we might also want to adjust their background colors, so I leave that out of this fix.

I also checked that it's safe to change `theme-flavor-inverse`. It's only used in the CSS for `span.CodeMirror-matchingbracket` (the subject of the issue above) and `span.CodeMirror-nonmatchingbracket` (the red highlighting for an unmatched bracket); the latter becomes black on red, which I think is okay too.