### PR TITLE
Fix package type in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 As anyone who has opened a bug report or feature request in the last several years can attest, I have begun scaling back support for the `jupyter-themes` package - mostly due to my personal preference for using Jupyter Lab over Jupyter Notebook classic (see update below for two of my JupyterLab theme repos).
 
-For those with continued interest in using `jupyter-themes` I am planning to write up a tutorial for how to add your own custom themes to your local `jt` installation as well as a contributing guide for those who would like submit pull-requests to the official pacakge.
+For those with continued interest in using `jupyter-themes` I am planning to write up a tutorial for how to add your own custom themes to your local `jt` installation as well as a contributing guide for those who would like submit pull-requests to the official package.
 
 I'll also take this opportunity to say ***thank you*** to everyone who regularly used, expressed appreciation for, and contributed to `jupyter-themes`. I'm particularly grateful to those of you who bothered to submit pull requests - adding many excellent features that I was either too short-sighted to anticipate or simply incapable of implementing on my own. So, thank you, sincerely.
 


### PR DESCRIPTION
There's a small type in how package is spelled in the readme. Not huge but it caught my eye. Figured I'd fix it for ya! Cheers and all the best.