### PR TITLE
Correct font size of pandas df index

### DIFF
--- a/jupyterthemes/layout/extras.less
+++ b/jupyterthemes/layout/extras.less
@@ -14,6 +14,9 @@
     font-family: @notebook-fontfamily !important;
     font-size: @df-fontsize;
 }
+.rendered_html th {
+    font-size: @df-fontsize;
+}
 .rendered_html table {
     font-family: @notebook-fontfamily !important;
     margin-left: 8px;


### PR DESCRIPTION
When printing a dataframe the index font size doesn't get updated with -dfs