### PR TITLE
Add tab completion using argcomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ jt  [-h] [-l] [-t THEME] [-f MONOFONT] [-fs MONOSIZE] [-nf NBFONT]
     [-cellw CELLWIDTH] [-lineh LINEHEIGHT] [-altp] [-altmd] [-altout]
     [-P] [-T] [-N] [-r] [-dfonts]
 ```
+Tab completion are available thanks to [argcomplete](https://kislyuk.github.io/argcomplete/#). Following the docs you can enable tab completion for your shell (bash, zsh, fish or tcsh).
 
 #### Description of Command Line options
 | cl options            |   arg   |  default   |

--- a/jupyterthemes/__init__.py
+++ b/jupyterthemes/__init__.py
@@ -1,9 +1,11 @@
 import os
-import sys
 from argparse import ArgumentParser
+from collections import ChainMap
 from glob import glob
+
+import argcomplete
+
 from . import stylefx
-from . import jtplot
 
 # path to local site-packages/jupyterthemes
 package_dir = os.path.dirname(os.path.realpath(__file__))
@@ -125,6 +127,9 @@ def install_theme(theme=None,
 
 def main():
     parser = ArgumentParser()
+    themes = get_themes()
+    themes.sort()
+    say_themes = "Available Themes: \n   {}".format('\n   '.join(themes))
     parser.add_argument(
         '-l',
         "--list",
@@ -135,13 +140,15 @@ def main():
         "--theme",
         default=None,
         action='store',
-        help="theme name to install")
+        help="theme name to install",
+        choices=themes)
     parser.add_argument(
         '-f',
         "--monofont",
         action='store',
         default=None,
-        help='monospace code font')
+        help='monospace code font',
+        choices=stylefx.fonts['mono'])
     parser.add_argument(
         '-fs',
         "--monosize",
@@ -153,7 +160,8 @@ def main():
         "--nbfont",
         action='store',
         default=None,
-        help='notebook font')
+        help='notebook font',
+        choices=ChainMap(*stylefx.fonts.values()))
     parser.add_argument(
         '-nfs',
         "--nbfontsize",
@@ -165,7 +173,8 @@ def main():
         "--tcfont",
         action='store',
         default=None,
-        help='txtcell font')
+        help='txtcell font',
+        choices=ChainMap(*stylefx.fonts.values()))
     parser.add_argument(
         '-tfs',
         "--tcfontsize",
@@ -286,10 +295,8 @@ def main():
         action='store_true',
         help="keep customization: do not reset jupyter notebook custom.js")
 
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
-    themes = get_themes()
-    themes.sort()
-    say_themes = "Available Themes: \n   {}".format('\n   '.join(themes))
 
     if args.reset:
         stylefx.reset_default(verbose=True)

--- a/jupyterthemes/stylefx.py
+++ b/jupyterthemes/stylefx.py
@@ -48,6 +48,57 @@ vim_style = os.path.join(layouts_dir, 'vim.less')
 comp_style = os.path.join(layouts_dir, 'completer.less')
 theme_name_file = os.path.join(jupyter_custom, 'current_theme.txt')
 
+fonts = {'mono':
+         {'anka': ['Anka/Coder', 'anka-coder'],
+          'anonymous': ['Anonymous Pro', 'anonymous-pro'],
+          'aurulent': ['Aurulent Sans Mono', 'aurulent'],
+          'bitstream': ['Bitstream Vera Sans Mono', 'bitstream-vera'],
+          'bpmono': ['BPmono', 'bpmono'],
+          'code': ['Code New Roman', 'code-new-roman'],
+          'consolamono': ['Consolamono', 'consolamono'],
+          'cousine': ['Cousine', 'cousine'],
+          'dejavu': ['DejaVu Sans Mono', 'dejavu'],
+          'droidmono': ['Droid Sans Mono', 'droidmono'],
+          'fira': ['Fira Mono', 'fira'],
+          'firacode': ['Fira Code', 'firacode'],
+          'generic': ['Generic Mono', 'generic'],
+          'hack': ['Hack', 'hack'],
+          'hasklig': ['Hasklig', 'hasklig'],
+          'iosevka' : ['Iosevka', 'iosevka'],
+          'inputmono': ['Input Mono', 'inputmono'],
+          'inconsolata': ['Inconsolata-g', 'inconsolata-g'],
+          'liberation': ['Liberation Mono', 'liberation'],
+          'meslo': ['Meslo', 'meslo'],
+          'office': ['Office Code Pro', 'office-code-pro'],
+          'oxygen': ['Oxygen Mono', 'oxygen'],
+          'roboto': ['Roboto Mono', 'roboto'],
+          'saxmono': ['saxMono', 'saxmono'],
+          'source': ['Source Code Pro', 'source-code-pro'],
+          'sourcemed': ['Source Code Pro Medium', 'source-code-medium'],
+          'sudovar': ['Sudo Variable', 'sudo-variable'],
+          'ptmono': ['PT Mono', 'ptmono'],
+          'ubuntu': ['Ubuntu Mono', 'ubuntu'],
+          'jetbrains' : ['JetBrains Mono', 'jetbrains']
+         },
+         'sans':
+         {'droidsans': ['Droid Sans', 'droidsans'],
+          'opensans': ['Open Sans', 'opensans'],
+          'ptsans': ['PT Sans', 'ptsans'],
+          'sourcesans': ['Source Sans Pro', 'sourcesans'],
+          'robotosans': ['Roboto', 'robotosans'],
+          'latosans': ['Lato', 'latosans'],
+          'exosans': ['Exo_2', 'exosans'],
+          'proxima': ['Proxima Nova', 'proximasans']},
+         'serif':
+         {'ptserif': ['PT Serif', 'ptserif'],
+          'ebserif': ['EB Garamond', 'ebserif'],
+          'loraserif': ['Lora', 'loraserif'],
+          'merriserif': ['Merriweather', 'merriserif'],
+          'crimsonserif': ['Crimson Text', 'crimsonserif'],
+          'georgiaserif': ['Georgia', 'georgiaserif'],
+          'neutonserif': ['Neuton', 'neutonserif'],
+          'cardoserif': ['Cardo Serif', 'cardoserif'],
+          'goudyserif': ['Goudy Serif', 'goudyserif']}}
 
 def fileOpen(filename, mode):
     if sys.version_info[0]==3:
@@ -529,57 +580,6 @@ def get_alt_prompt_text_color(theme):
 
 
 def stored_font_dicts(fontcode, get_all=False):
-    fonts = {'mono':
-             {'anka': ['Anka/Coder', 'anka-coder'],
-              'anonymous': ['Anonymous Pro', 'anonymous-pro'],
-              'aurulent': ['Aurulent Sans Mono', 'aurulent'],
-              'bitstream': ['Bitstream Vera Sans Mono', 'bitstream-vera'],
-              'bpmono': ['BPmono', 'bpmono'],
-              'code': ['Code New Roman', 'code-new-roman'],
-              'consolamono': ['Consolamono', 'consolamono'],
-              'cousine': ['Cousine', 'cousine'],
-              'dejavu': ['DejaVu Sans Mono', 'dejavu'],
-              'droidmono': ['Droid Sans Mono', 'droidmono'],
-              'fira': ['Fira Mono', 'fira'],
-              'firacode': ['Fira Code', 'firacode'],
-              'generic': ['Generic Mono', 'generic'],
-              'hack': ['Hack', 'hack'],
-              'hasklig': ['Hasklig', 'hasklig'],
-              'iosevka' : ['Iosevka', 'iosevka'],
-              'inputmono': ['Input Mono', 'inputmono'],
-              'inconsolata': ['Inconsolata-g', 'inconsolata-g'],
-              'liberation': ['Liberation Mono', 'liberation'],
-              'meslo': ['Meslo', 'meslo'],
-              'office': ['Office Code Pro', 'office-code-pro'],
-              'oxygen': ['Oxygen Mono', 'oxygen'],
-              'roboto': ['Roboto Mono', 'roboto'],
-              'saxmono': ['saxMono', 'saxmono'],
-              'source': ['Source Code Pro', 'source-code-pro'],
-              'sourcemed': ['Source Code Pro Medium', 'source-code-medium'],
-              'sudovar': ['Sudo Variable', 'sudo-variable'],
-              'ptmono': ['PT Mono', 'ptmono'],
-              'ubuntu': ['Ubuntu Mono', 'ubuntu'],
-              'jetbrains' : ['JetBrains Mono', 'jetbrains']
-             },
-             'sans':
-             {'droidsans': ['Droid Sans', 'droidsans'],
-              'opensans': ['Open Sans', 'opensans'],
-              'ptsans': ['PT Sans', 'ptsans'],
-              'sourcesans': ['Source Sans Pro', 'sourcesans'],
-              'robotosans': ['Roboto', 'robotosans'],
-              'latosans': ['Lato', 'latosans'],
-              'exosans': ['Exo_2', 'exosans'],
-              'proxima': ['Proxima Nova', 'proximasans']},
-             'serif':
-             {'ptserif': ['PT Serif', 'ptserif'],
-              'ebserif': ['EB Garamond', 'ebserif'],
-              'loraserif': ['Lora', 'loraserif'],
-              'merriserif': ['Merriweather', 'merriserif'],
-              'crimsonserif': ['Crimson Text', 'crimsonserif'],
-              'georgiaserif': ['Georgia', 'georgiaserif'],
-              'neutonserif': ['Neuton', 'neutonserif'],
-              'cardoserif': ['Cardo Serif', 'cardoserif'],
-              'goudyserif': ['Goudy Serif', 'goudyserif']}}
     if get_all:
         return fonts
     if fontcode in list(fonts['mono']):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ notebook>=5.6.0
 ipython>=5.4.1
 matplotlib>=1.4.3
 lesscpy>=0.11.2
+argcomplete>=2.0.0


### PR DESCRIPTION
With very few code changes tab completion can be add to `jt` cli. 

I found this very useful when trying to set new theme. I type `jt -t ` and then I press Tab: all available themes are listed below so it's easy to chose. Moreover when I type `jt -t darkbr` and the press Tab, it autocomplete to `jt -t darkbronco` avoiding any typos. 

Completions are enable for `jt` commands and `-t`, `-f`, `-nf`, `-tf` flags.