### PR TITLE
Update monokai.less

### DIFF
--- a/jupyterthemes/styles/monokai.less
+++ b/jupyterthemes/styles/monokai.less
@@ -149,7 +149,7 @@
 @cm-selected:           #49483E;
 @cm-gutters:            @cm-selected;
 @cm-linenumber:         @disabled;
-@cm-comment:            #75715E;
+@cm-comment:            #00FFCC;
 @cm-atom:               @violet;
 @cm-number:             @violet;
 @cm-property:           @green;


### PR DESCRIPTION
Let's change the color of COMMENTS in dark monokai theme ? Let's make it more VISIBLE, let's say greenish-blueish.. Because dark gray looks like.. well, it's hard to say what it looks like in dark theme. I bet people will appreciate clear vivid comments..